### PR TITLE
feat(sources): add CachePathForURL helper

### DIFF
--- a/internal/sources/cache.go
+++ b/internal/sources/cache.go
@@ -1,0 +1,22 @@
+package sources
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+)
+
+// CachePathForURL converts a URL to a local cache file path using SHA256 hash.
+// The hash ensures unique filenames while preserving the original extension.
+//
+// Example:
+//
+//	CachePathForURL("/tmp/cache", "https://example.com/data.zip")
+//	// Returns: /tmp/cache/abc123...def.zip
+func CachePathForURL(cacheDir, url string) string {
+	ext := filepath.Ext(url)
+	hasher := sha256.New()
+	hasher.Write([]byte(url))
+	hash := hex.EncodeToString(hasher.Sum(nil))
+	return filepath.Join(cacheDir, hash+ext)
+}

--- a/internal/sources/cache_test.go
+++ b/internal/sources/cache_test.go
@@ -1,0 +1,89 @@
+package sources
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCachePathForURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		cacheDir string
+		url      string
+		wantExt  string
+	}{
+		{
+			name:     "zip extension",
+			cacheDir: "/tmp/cache",
+			url:      "https://example.com/data.zip",
+			wantExt:  ".zip",
+		},
+		{
+			name:     "json extension",
+			cacheDir: "/tmp/cache",
+			url:      "https://api.example.com/data.json",
+			wantExt:  ".json",
+		},
+		{
+			name:     "no extension",
+			cacheDir: "/tmp/cache",
+			url:      "https://example.com/data",
+			wantExt:  "",
+		},
+		{
+			name:     "geojson extension",
+			cacheDir: "/home/user/.cache",
+			url:      "https://geo.example.com/file.geojson",
+			wantExt:  ".geojson",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CachePathForURL(tt.cacheDir, tt.url)
+
+			// Check it starts with cache dir
+			if !strings.HasPrefix(got, tt.cacheDir) {
+				t.Errorf("CachePathForURL() = %q, want prefix %q", got, tt.cacheDir)
+			}
+
+			// Check extension is preserved
+			if filepath.Ext(got) != tt.wantExt {
+				t.Errorf("CachePathForURL() ext = %q, want %q", filepath.Ext(got), tt.wantExt)
+			}
+
+			// Check hash is 64 chars (SHA256 hex = 64 chars)
+			base := filepath.Base(got)
+			hashPart := strings.TrimSuffix(base, tt.wantExt)
+			if len(hashPart) != 64 {
+				t.Errorf("CachePathForURL() hash length = %d, want 64", len(hashPart))
+			}
+		})
+	}
+}
+
+func TestCachePathForURL_DifferentURLs(t *testing.T) {
+	cacheDir := "/tmp/cache"
+	url1 := "https://example.com/file1.zip"
+	url2 := "https://example.com/file2.zip"
+
+	path1 := CachePathForURL(cacheDir, url1)
+	path2 := CachePathForURL(cacheDir, url2)
+
+	if path1 == path2 {
+		t.Errorf("Different URLs should produce different paths: %q == %q", path1, path2)
+	}
+}
+
+func TestCachePathForURL_Deterministic(t *testing.T) {
+	cacheDir := "/tmp/cache"
+	url := "https://example.com/data.zip"
+
+	path1 := CachePathForURL(cacheDir, url)
+	path2 := CachePathForURL(cacheDir, url)
+
+	if path1 != path2 {
+		t.Errorf("Same URL should produce same path: %q != %q", path1, path2)
+	}
+}


### PR DESCRIPTION
## Summary

Implements URL-to-cache-path conversion using SHA256 hash. This is the foundation for the HTTP fetcher's caching system.

- `CachePathForURL(cacheDir, url string) string` - converts URL to deterministic local path
- Preserves original file extension
- SHA256 ensures unique filenames without collisions

## LLM Experiment Notes

This PR was created as part of testing the hybrid Claude + local LLM workflow:

1. **Prompt sent to qwen2.5-coder:3b via clood**
2. **LLM output**: Generated working code with minor bug (redundant hex encoding)
3. **Human fix**: Fixed filepath.Join and removed redundant encoding
4. **Tests**: Written by Claude (LLM-generated tests were poor - made up expected values)

### Lessons Learned
- Local LLM good at basic function implementation
- Local LLM poor at writing tests (needs concrete examples)
- Hybrid approach: LLM generates, Claude/human reviews and fixes

## Test Plan

- [x] `go test ./internal/sources/...` passes
- [x] Different URLs produce different hashes
- [x] Same URL always produces same path
- [x] File extension preserved

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)