### PR TITLE
feat(output): add SVG writer skeleton

### DIFF
--- a/internal/output/svg.go
+++ b/internal/output/svg.go
@@ -1,0 +1,48 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SVGWriter generates SVG output for map geometries
+type SVGWriter struct {
+	Width  int
+	Height int
+}
+
+// NewSVGWriter creates a writer with the given dimensions
+func NewSVGWriter(width, height int) *SVGWriter {
+	return &SVGWriter{
+		Width:  width,
+		Height: height,
+	}
+}
+
+// Header returns the SVG opening tag with viewBox
+func (s *SVGWriter) Header() string {
+	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d">`, s.Width, s.Height)
+}
+
+// Footer returns the SVG closing tag
+func (s *SVGWriter) Footer() string {
+	return "</svg>"
+}
+
+// PolygonToPath converts a slice of points to an SVG path d attribute
+func (s *SVGWriter) PolygonToPath(points [][2]float64) string {
+	if len(points) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for i, point := range points {
+		if i == 0 {
+			parts = append(parts, fmt.Sprintf("M %.2f %.2f", point[0], point[1]))
+		} else {
+			parts = append(parts, fmt.Sprintf("L %.2f %.2f", point[0], point[1]))
+		}
+	}
+	parts = append(parts, "Z")
+	return strings.Join(parts, " ")
+}

--- a/internal/output/svg_test.go
+++ b/internal/output/svg_test.go
@@ -1,0 +1,99 @@
+package output
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewSVGWriter(t *testing.T) {
+	w := NewSVGWriter(800, 600)
+
+	if w.Width != 800 {
+		t.Errorf("Width = %d, want 800", w.Width)
+	}
+	if w.Height != 600 {
+		t.Errorf("Height = %d, want 600", w.Height)
+	}
+}
+
+func TestSVGWriter_Header(t *testing.T) {
+	w := NewSVGWriter(800, 600)
+	header := w.Header()
+
+	if !strings.Contains(header, "xmlns") {
+		t.Error("Header missing xmlns attribute")
+	}
+	if !strings.Contains(header, "viewBox") {
+		t.Error("Header missing viewBox attribute")
+	}
+	if !strings.Contains(header, "800") || !strings.Contains(header, "600") {
+		t.Error("Header missing dimensions")
+	}
+	if !strings.HasPrefix(header, "<svg") {
+		t.Error("Header should start with <svg")
+	}
+}
+
+func TestSVGWriter_Footer(t *testing.T) {
+	w := NewSVGWriter(100, 100)
+	footer := w.Footer()
+
+	if footer != "</svg>" {
+		t.Errorf("Footer = %q, want </svg>", footer)
+	}
+}
+
+func TestSVGWriter_PolygonToPath(t *testing.T) {
+	w := NewSVGWriter(100, 100)
+
+	tests := []struct {
+		name   string
+		points [][2]float64
+		want   string
+	}{
+		{
+			name:   "square",
+			points: [][2]float64{{0, 0}, {100, 0}, {100, 100}, {0, 100}},
+			want:   "M 0.00 0.00 L 100.00 0.00 L 100.00 100.00 L 0.00 100.00 Z",
+		},
+		{
+			name:   "triangle",
+			points: [][2]float64{{50, 0}, {100, 100}, {0, 100}},
+			want:   "M 50.00 0.00 L 100.00 100.00 L 0.00 100.00 Z",
+		},
+		{
+			name:   "empty",
+			points: [][2]float64{},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := w.PolygonToPath(tt.points)
+			if got != tt.want {
+				t.Errorf("PolygonToPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSVGWriter_RoundTrip(t *testing.T) {
+	w := NewSVGWriter(200, 150)
+
+	// Build a complete SVG
+	svg := w.Header() + "\n"
+	svg += `<path d="` + w.PolygonToPath([][2]float64{{10, 10}, {190, 10}, {190, 140}, {10, 140}}) + `"/>` + "\n"
+	svg += w.Footer()
+
+	// Verify structure
+	if !strings.HasPrefix(svg, "<svg") {
+		t.Error("SVG should start with <svg")
+	}
+	if !strings.HasSuffix(svg, "</svg>") {
+		t.Error("SVG should end with </svg>")
+	}
+	if !strings.Contains(svg, "<path") {
+		t.Error("SVG should contain path element")
+	}
+}


### PR DESCRIPTION
## Summary

Basic SVG output generation for Chimborazo map rendering.

**Implements:**
- `SVGWriter` struct with configurable dimensions
- `Header()` / `Footer()` for SVG document structure
- `PolygonToPath()` for converting geometry to SVG path commands

## LLM Experiment Notes

| Task | Model | Quality | Notes |
|------|-------|---------|-------|
| Code generation | qwen2.5-coder:7b | ✅ Good | Clean, working code |
| PR description | tinyllama | ❌ Poor | Hallucinated features |

**Finding**: Coder models good for code, but tinyllama hallucinated when asked to describe the code. Need better model for text generation.

## Test Plan

- [x] `go test ./internal/output/...` passes
- [x] Header includes xmlns and viewBox
- [x] PolygonToPath generates valid SVG path syntax
- [x] Empty polygon returns empty string

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)